### PR TITLE
Improved awplus_interfaces module.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/plugins/module_utils/config/interfaces/interfaces.py
+++ b/plugins/module_utils/config/interfaces/interfaces.py
@@ -152,8 +152,6 @@ class Interfaces(ConfigBase):
                 elif interface["name"] in each["name"]:
                     break
             else:
-                # configuring non-existing interface
-                commands.extend(self._set_config(interface, dict()))
                 continue
             have_dict = filter_dict_having_none_value(interface, each)
             commands.extend(self._clear_config(dict(), have_dict))
@@ -219,8 +217,6 @@ class Interfaces(ConfigBase):
                 if each["name"] == interface["name"]:
                     break
             else:
-                # configuring non-existing interface
-                commands.extend(self._set_config(interface, dict()))
                 continue
             # commands.extend(self._clear_config(dict(), have_dict))
             commands.extend(self._set_config(interface, each))
@@ -311,13 +307,5 @@ class Interfaces(ConfigBase):
             and want.get("duplex") != have.get("duplex")
         ):
             remove_command_from_config_list(interface, "duplex", commands)
-
-        # if interface_type.lower() == 'gigabitethernet':
-        #     if have.get('speed') and have.get('speed') != 'auto' and want.get('speed') != have.get('speed'):
-        #         remove_command_from_config_list(interface, 'speed', commands)
-        #     if have.get('duplex') and have.get('duplex') != 'auto' and want.get('duplex') != have.get('duplex'):
-        #         remove_command_from_config_list(interface, 'duplex', commands)
-        #     if have.get('mtu') and want.get('mtu') != have.get('mtu'):
-        #         remove_command_from_config_list(interface, 'mtu', commands)
 
         return commands

--- a/plugins/module_utils/config/interfaces/interfaces.py
+++ b/plugins/module_utils/config/interfaces/interfaces.py
@@ -151,9 +151,7 @@ class Interfaces(ConfigBase):
                 if intf_type == "unknown":
                     self._module.fail_json("Invalid interface name - unknown interface")
                 if int_type != intf_type:
-                    self._module.fail_json(
-                        f"Interfaces mismatch {int_type} & {intf_type}, "
-                        "Interfaces in range must be of the same type")
+                    self._module.fail_json("Interfaces mismatch, Interfaces in range must be of the same type")
             return intfs
         else:
             return [want]
@@ -238,7 +236,7 @@ class Interfaces(ConfigBase):
             for intf in intfs:
                 have_dict = self.get_have_dict(intf, have)
                 if have_dict is None:
-                    self._module.fail_json(msg=f"{intf} does not exist")
+                    self._module.fail_json(msg="Interface does not exist")
             else:
                 if have_dict:
                     filtered_have = filter_dict_having_none_value(interface, have_dict)
@@ -289,7 +287,7 @@ class Interfaces(ConfigBase):
             for intf in intfs:
                 have_dict = self.get_have_dict(intf, have)
                 if have_dict is None:
-                    self._module.fail_json(msg=f"{intf} does not exist")
+                    self._module.fail_json(msg="Interface does not exist")
             else:
                 if have_dict:
                     commands.extend(self._set_config(interface, have_dict))
@@ -315,7 +313,7 @@ class Interfaces(ConfigBase):
             for intf in intfs:
                 have_dict = self.get_have_dict(intf, have)
                 if have_dict is None:
-                    self._module.fail_json(msg=f"{intf} does not exist")
+                    self._module.fail_json(msg="Interface does not exist")
             else:
                 if have_dict:
                     commands.extend(self._set_config(interface, have_dict))
@@ -341,7 +339,7 @@ class Interfaces(ConfigBase):
                 for intf in intfs:
                     have_dict = self.get_have_dict(intf, have)
                     if have_dict is None:
-                        self._module.fail_json(msg=f"Can't parse interface, {intf} may not exist")
+                        self._module.fail_json(msg="Interface does not exist")
                 else:
                     if have_dict:
                         interface = dict(name=interface["name"])

--- a/plugins/module_utils/config/interfaces/interfaces.py
+++ b/plugins/module_utils/config/interfaces/interfaces.py
@@ -174,9 +174,9 @@ class Interfaces(ConfigBase):
             port = re.search(r"port(\d+).(\d+).(\d+)-(\d+).(\d+).(\d+)", want)
             if port:
                 for i in range(3):  # check if valid range
-                    if port.group(i + 1) > port.group(i + 4):
+                    if int(port.group(i + 1)) > int(port.group(i + 4)):
                         self._module.fail_json("Invalid Input - range end must be greater than range start")
-                    elif port.group(i + 1) == port.group(i + 4):
+                    elif int(port.group(i + 1)) == int(port.group(i + 4)):
                         continue
                     else:
                         break
@@ -210,7 +210,7 @@ class Interfaces(ConfigBase):
         if "-" in want:
             intf_range = re.search(r"([a-z]+)(\d+)-(\d+)", want)
             if intf_range:
-                if intf_range.group(3) <= intf_range.group(2):
+                if int(intf_range.group(3)) <= int(intf_range.group(2)):
                     self._module.fail_json("Invalid Input - range end must be greater than range start")
                 for i in range(int(intf_range.group(2)), int(intf_range.group(3)) + 1):
                     for intf in have:  # check if all interfaces in range exists

--- a/plugins/module_utils/utils/utils.py
+++ b/plugins/module_utils/utils/utils.py
@@ -190,30 +190,24 @@ def normalize_interface(name):
                 digits += char
         return digits
 
-    if name.lower().startswith("gi"):
-        if_type = "GigabitEthernet"
-    elif name.lower().startswith("te"):
-        if_type = "TenGigabitEthernet"
-    elif name.lower().startswith("fa"):
-        if_type = "FastEthernet"
-    elif name.lower().startswith("fo"):
-        if_type = "FortyGigabitEthernet"
-    elif name.lower().startswith("long"):
-        if_type = "LongReachEthernet"
-    elif name.lower().startswith("et"):
-        if_type = "Ethernet"
+    if name.lower().startswith("et"):
+        if_type = "eth"
     elif name.lower().startswith("vl"):
         if_type = "vlan"
     elif name.lower().startswith("lo"):
-        if_type = "loopback"
-    elif name.lower().startswith("po"):
+        if_type = "lo"
+    elif name.lower().startswith("por"):
         if_type = "port"
-    elif name.lower().startswith("nv"):
-        if_type = "nve"
-    elif name.lower().startswith("twe"):
-        if_type = "TwentyFiveGigE"
-    elif name.lower().startswith("hu"):
-        if_type = "HundredGigE"
+    elif name.lower().startswith("po"):
+        if_type = "po"
+    elif name.lower().startswith("sa"):
+        if_type = "sa"
+    elif name.lower().startswith("br"):
+        if_type = "br"
+    elif name.lower().startswith("of"):
+        if_type = "of"
+    elif name.lower().startswith("tu"):
+        if_type = "tunnel"
     else:
         if re.search(r"(\d+\.\d+\.\d+)", name):
             if_type = "port"
@@ -238,30 +232,24 @@ def get_interface_type(interface):
     """Gets the type of interface
     """
 
-    if interface.upper().startswith("GI"):
-        return "GigabitEthernet"
-    elif interface.upper().startswith("TE"):
-        return "TenGigabitEthernet"
-    elif interface.upper().startswith("FA"):
-        return "FastEthernet"
-    elif interface.upper().startswith("FO"):
-        return "FortyGigabitEthernet"
-    elif interface.upper().startswith("LON"):
-        return "LongReachEthernet"
-    elif interface.upper().startswith("ET"):
-        return "Ethernet"
+    if interface.upper().startswith("ET"):
+        return "ethernet"
     elif interface.upper().startswith("VL"):
         return "vlan"
     elif interface.upper().startswith("LO"):
         return "loopback"
-    elif interface.upper().startswith("PO"):
+    elif interface.upper().startswith("POR"):
         return "port"
-    elif interface.upper().startswith("NV"):
-        return "nve"
-    elif interface.upper().startswith("TWE"):
-        return "TwentyFiveGigE"
-    elif interface.upper().startswith("HU"):
-        return "HundredGigE"
+    elif interface.upper().startswith("PO"):
+        return "dynamic aggregator"
+    elif interface.upper().startswith("SA"):
+        return "static aggregator"
+    elif interface.upper().startswith("BR"):
+        return "bridge"
+    elif interface.upper().startswith("OF"):
+        return "openflow"
+    elif interface.upper().startswith("TU"):
+        return "tunnel"
     else:
         if re.search(r"(\d+\.\d+\.\d+)", interface):
             return "port"

--- a/plugins/modules/awplus_interfaces.py
+++ b/plugins/modules/awplus_interfaces.py
@@ -8,27 +8,21 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
-
 DOCUMENTATION = """
 ---
-module: awplus_interfaces
+module: alliedtelesis.awplus.awplus_interfaces
 author: Cheng Yi Kok (@cyk19)
-short_description: 'Manages attribute of AlliedWare Plus interfaces.'
-description: 'Manages attribute of AlliedWare Plus network interfaces'
+short_description: Manages attribute of AlliedWare Plus interfaces
+description: Manages attribute of AlliedWare Plus network interfaces.
 version_added: "2.9"
 options:
   config:
-    description: A dictionary of interface options
+    description: A dictionary of interface options.
     type: list
     suboptions:
       name:
         description:
-        - Full name of interface, e.g. GigabitEthernet0/2, loopback999.
+        - Full name of interface, e.g. port1.0.3, vlan2.
         type: str
         required: True
       description:
@@ -43,457 +37,412 @@ options:
         default: True
       speed:
         description:
-        - Interface link speed. Applicable for Ethernet interfaces only.
+        - Interface link speed. Applicable for switchport interfaces only.
         type: str
       mtu:
         description:
-        - MTU for a specific interface. Applicable for Ethernet interfaces only.
-        - Refer to vendor documentation for valid values.
+        - MTU size for a specific interface. Applicable for VLAN interfaces only.
+        - Refer to documentation for valid values.
         type: int
       duplex:
         description:
-        - Interface link status. Applicable for Ethernet interfaces only, either in half duplex,
+        - Interface link status. Applicable for switchport interfaces only, either in half duplex,
           full duplex or in automatic state which negotiates the duplex automatically.
         type: str
         choices: ['full', 'half', 'auto']
   state:
-    choices:
-    - merged
-    - replaced
-    - overridden
-    - deleted
-    default: merged
     description:
-    - The state of the configuration after module completion
+    - The state of the configuration after module completion.
+    choices: ['merged', 'replaced', 'overridden', 'deleted']
+    default: merged
     type: str
 """
 
 EXAMPLES = """
 # Using merged
 
-Before state:
-------------------
-interface port1.0.1
- switchport
- switchport mode access
-!
-interface port1.0.2
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.3
- speed 1000
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.4
- duplex full
- switchport
- switchport mode access
-!
-interface vlan1
- ip address 192.168.5.2/24
- ipv6 enable
- ipv6 address dhcp
- ip dhcp-client vendor-identifying-class
- ip dhcp-client request vendor-identifying-specific
-!
+# Before state:
+# ------------------
+# interface port1.0.1
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.2
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.3
+#  speed 1000
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.4
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface vlan1
+#  ip address 192.168.5.2/24
+#  ipv6 enable
+#  ipv6 address dhcp
+#  ip dhcp-client vendor-identifying-class
+#  ip dhcp-client request vendor-identifying-specific
+# !
 
-    - name: Test awplus_interface module
-    connection: network_cli
-    hosts: all
-    tasks:
-      - name: Merge provided configuration with device configuration
-        awplus_interfaces:
-          config:
-            - name: port1.0.2
-              description: Merged by Ansible Network
-              duplex: full
+- name: Merge provided configuration with device configuration
+  alliedtelesis.awplus.awplus_interfaces:
+    config:
+      - name: port1.0.2
+        description: Merged by Ansible Network
+        duplex: full
 
-              # vlan1 does not have duplex configuration option
-            - name: vlan1
-              description: Merged by Ansible Network
-              mtu: 1500 # in the range <68-1582> ; Changed mtu config doesn't show in CLI
-          state: merged
+        # vlan1 does not have duplex configuration option
+      - name: vlan1
+        description: Merged by Ansible Network
+        mtu: 234 # in the range <68-1582>
+    state: merged
 
-After state:
----------------------
-interface port1.0.1
- switchport
- switchport mode access
-!
-interface port1.0.2
- description Merged by Ansible Network
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.3
- speed 1000
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.4
- duplex full
- switchport
- switchport mode access
-!
-interface vlan1
- description Merged by Ansible Network
- ip address 192.168.5.2/24
- ipv6 enable
- ipv6 address dhcp
- ip dhcp-client vendor-identifying-class
- ip dhcp-client request vendor-identifying-specific
-!
+# After state:
+# ---------------------
+# interface port1.0.1
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.2
+#  description Merged by Ansible Network
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.3
+#  speed 1000
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.4
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface vlan1
+#  description Merged by Ansible Network
+#  mtu 234
+#  ip address 192.168.5.2/24
+#  ipv6 enable
+#  ipv6 address dhcp
+#  ip dhcp-client vendor-identifying-class
+#  ip dhcp-client request vendor-identifying-specific
+# !
 
-Using replaced:
+# Using replaced:
 
-Before state:
----------------------
-interface port1.0.1
- switchport
- switchport mode access
-!
-interface port1.0.2
- description Merged by Ansible Network
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.3
- speed 1000
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.4
- duplex full
- switchport
- switchport mode access
-!
-interface vlan1
- description Merged by Ansible Network
- ip address 192.168.5.2/24
- ipv6 enable
- ipv6 address dhcp
- ip dhcp-client vendor-identifying-class
- ip dhcp-client request vendor-identifying-specific
-!
+# Before state:
+# ---------------------
+# interface port1.0.1
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.2
+#  description Merged by Ansible Network
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.3
+#  speed 1000
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.4
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface vlan1
+#  description Merged by Ansible Network
+#  ip address 192.168.5.2/24
+#  ipv6 enable
+#  ipv6 address dhcp
+#  ip dhcp-client vendor-identifying-class
+#  ip dhcp-client request vendor-identifying-specific
+# !
 
-  - name: Test awplus_interface module
-    connection: network_cli
-    hosts: all
-    tasks:
-      - name: Replace device configuration with provided configuration
-        awplus_interfaces:
-          config:
-            - name: port1.0.3
-              description: Replaced by Ansible Network
-              duplex: full
-              # Available options for speed:
-              # 10, 100, 1000, 10000, 100000, (mbps)
-              # 2500, 40000, 5000, auto (mbps)
-              speed: 1000
-              enabled: False
+- name: Replace device configuration with provided configuration
+  alliedtelesis.awplus.awplus_interfaces:
+    config:
+      - name: port1.0.3
+        description: Replaced by Ansible Network
+        duplex: full
+        # Available options for speed:
+        # 10, 100, 1000, 10000, 100000, (mbps)
+        # 2500, 40000, 5000, auto (mbps)
+        speed: 1000
+        enabled: False
 
-              # vlan1 does not have duplex configuration option
-            - name: vlan1
-              description: Replaced by Ansible Network
-              mtu: 900 # in the range <68-1582>
-              enabled: True
-          state: replaced
+        # vlan1 does not have duplex configuration option
+      - name: vlan1
+        description: Replaced by Ansible Network
+        mtu: 900 # in the range <68-1582>
+        enabled: True
+    state: replaced
 
-After state:
----------------------
-interface port1.0.1
- switchport
- switchport mode access
-!
-interface port1.0.2
- description Merged by Ansible Network
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.3
- description Replaced by Ansible Network
- speed 1000
- duplex full
- shutdown
- switchport
- switchport mode access
-!
-interface port1.0.4
- duplex full
- switchport
- switchport mode access
-!
-interface vlan1
- description Replaced by Ansible Network
- ip address 192.168.5.2/24
- ipv6 enable
- ipv6 address dhcp
- ip dhcp-client vendor-identifying-class
- ip dhcp-client request vendor-identifying-specific
-!
+# After state:
+# ---------------------
+# interface port1.0.1
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.2
+#  description Merged by Ansible Network
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.3
+#  description Replaced by Ansible Network
+#  speed 1000
+#  duplex full
+#  shutdown
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.4
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface vlan1
+#  description Replaced by Ansible Network
+#  ip address 192.168.5.2/24
+#  ipv6 enable
+#  ipv6 address dhcp
+#  ip dhcp-client vendor-identifying-class
+#  ip dhcp-client request vendor-identifying-specific
+# !
 
-Using overridden
+# Using overridden
 
-Before state:
-------------------------
-interface port1.0.1
- switchport
- switchport mode access
-!
-interface port1.0.2
- description Merged by Ansible Network
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.3
- description Replaced by Ansible Network
- speed 1000
- duplex full
- shutdown
- switchport
- switchport mode access
-!
-interface port1.0.4
- duplex full
- switchport
- switchport mode access
-!
-interface vlan1
- description Replaced by Ansible Network
- ip address 192.168.5.2/24
- ipv6 enable
- ipv6 address dhcp
- ip dhcp-client vendor-identifying-class
- ip dhcp-client request vendor-identifying-specific
-!
+# Before state:
+# ------------------------
+# interface port1.0.1
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.2
+#  description Merged by Ansible Network
+#  duplex full
+#  switchport
+#  switchport mode trunk
+#  switchport trunk allowed vlan add 5-6,13
+#  switchport trunk native vlan none
+# !
+# interface port1.0.3
+#  description Replaced by Ansible Network
+#  speed 1000
+#  duplex full
+#  shutdown
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.4-1.0.28
+#  switchport
+#  switchport mode access
+# !
+# # interface vlan1
+#  ip helper-address 172.26.3.8
+# !
+# interface vlan2
+#  ip address dhcp client-id vlan2 hostname test.com
+# !
+# interface vlan5
+#  description Replaced by Ansible Network
+#  mtu 900
+# !
+# interface vlan13
+#  ip address 13.13.13.13/24
 
----
-  - name: Test awplus_interface module
-    connection: network_cli
-    hosts: all
-    tasks:
-      - name: Override device configuration of all interfaces with provided configuration
-        awplus_interfaces:
-          config:
-            - name: port1.0.4
-              description: Override by Ansible Network
-              duplex: full
-              # Available options for speed:
-              # 10, 100, 1000, 10000, 100000, (mbps)
-              # 2500, 40000, 5000, auto (mbps)
-              speed: 2500
-              enabled: True
+- name: Override device configuration of all interfaces with provided configuration
+  alliedtelesis.awplus.awplus_interfaces:
+    config:
+      - name: port1.0.2
+        description: Overridden by Ansible Network
+        duplex: full
+        speed: 2500
+        enabled: True
 
-              # vlan1 does not have duplex configuration option
-            - name: vlan1
-              description: Override by Ansible Network
-              mtu: 900 # in the range <68-1582>
-              enabled: True
-          state: replaced
+      - name: vlan2
+        description: Overridden by Ansible Network
+        mtu: 920
+        enabled: True
+    state: overriden
 
-After state:
--------------------------
-interface port1.0.1
- switchport
- switchport mode access
-!
-interface port1.0.2
- description Merged by Ansible Network
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.3
- description Replaced by Ansible Network
- speed 1000
- duplex full
- shutdown
- switchport
- switchport mode access
-!
-interface port1.0.4
- description Override by Ansible Network
- duplex full
- switchport
- switchport mode access
-!
-interface vlan1
- description Override by Ansible Network
- ip address 192.168.5.2/24
- ipv6 enable
- ipv6 address dhcp
- ip dhcp-client vendor-identifying-class
- ip dhcp-client request vendor-identifying-specific
-!
+# After state:
+# -------------------------
+# interface port1.0.1
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.2
+#  description Overridden by Ansible Network
+#  duplex full
+#  switchport
+#  switchport mode trunk
+#  switchport trunk allowed vlan add 5-6,13
+#  switchport trunk native vlan none
+# !
+# interface port1.0.3-1.0.28
+#  switchport
+#  switchport mode access
+# !
+# interface vlan1
+#  ip helper-address 172.26.3.8
+# !
+# interface vlan2
+#  description Overridden by Ansible Network
+#  mtu 920
+#  ip address dhcp client-id vlan2 hostname test.com
+# !
+# interface vlan13
+#  ip address 13.13.13.13/24
+# !
 
-Using Deleted
+# Using Deleted
 
-Before state:
----------------------
-interface port1.0.1
- switchport
- switchport mode access
-!
-interface port1.0.2
- description Merged by Ansible Network
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.3
- description Replaced by Ansible Network
- speed 1000
- duplex full
- shutdown
- switchport
- switchport mode access
-!
-interface port1.0.4
- description Override by Ansible Network
- duplex full
- switchport
- switchport mode access
-!
-interface vlan1
- description Override by Ansible Network
- ip address 192.168.5.2/24
- ipv6 enable
- ipv6 address dhcp
- ip dhcp-client vendor-identifying-class
- ip dhcp-client request vendor-identifying-specific
-!
+# Before state:
+# ---------------------
+# interface port1.0.1
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.2
+#  description Merged by Ansible Network
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.3
+#  description Replaced by Ansible Network
+#  speed 1000
+#  duplex full
+#  shutdown
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.4
+#  description Override by Ansible Network
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface vlan1
+#  description Override by Ansible Network
+#  ip address 192.168.5.2/24
+#  ipv6 enable
+#  ipv6 address dhcp
+#  ip dhcp-client vendor-identifying-class
+#  ip dhcp-client request vendor-identifying-specific
+# !
 
-  - name: Test awplus_interface module
-    connection: network_cli
-    hosts: all
-    tasks:
-      - name: "Delete module attributes of given interfaces (Note: This won't delete the interface itself)"
-        awplus_interfaces:
-          config:
-            - name: port1.0.2
-          state: deleted
+- name: Delete module attributes of given interfaces (Note: This won't delete the interface itself)
+  alliedtelesis.awplus.awplus_interfaces:
+    config:
+      - name: port1.0.2
+    state: deleted
 
-After state:
----------------------------
-interface port1.0.1
- switchport
- switchport mode access
-!
-interface port1.0.2
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.3
- description Replaced by Ansible Network
- speed 1000
- duplex full
- shutdown
- switchport
- switchport mode access
-!
-interface port1.0.4
- description Override by Ansible Network
- duplex full
- switchport
- switchport mode access
-!
-interface vlan1
- description Override by Ansible Network
- ip address 192.168.5.2/24
- ipv6 enable
- ipv6 address dhcp
- ip dhcp-client vendor-identifying-class
- ip dhcp-client request vendor-identifying-specific
-!
+# After state:
+# ---------------------------
+# interface port1.0.1
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.2
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.3
+#  description Replaced by Ansible Network
+#  speed 1000
+#  duplex full
+#  shutdown
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.4
+#  description Override by Ansible Network
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface vlan1
+#  description Override by Ansible Network
+#  ip address 192.168.5.2/24
+#  ipv6 enable
+#  ipv6 address dhcp
+#  ip dhcp-client vendor-identifying-class
+#  ip dhcp-client request vendor-identifying-specific
+# !
 
-Using Deleted without any config passed
-NOTE: This will delete all of configured resource module attributes from each configured interface
+# Using Deleted without any config passed
+# NOTE: This will delete all of configured resource module attributes from each configured interface
 
-Before state:
------------------------
-interface port1.0.1
- switchport
- switchport mode access
-!
-interface port1.0.2
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.3
- description Replaced by Ansible Network
- speed 1000
- duplex full
- shutdown
- switchport
- switchport mode access
-!
-interface port1.0.4
- description Override by Ansible Network
- duplex full
- switchport
- switchport mode access
-!
-interface vlan1
- description Override by Ansible Network
- ip address 192.168.5.2/24
- ipv6 enable
- ipv6 address dhcp
- ip dhcp-client vendor-identifying-class
- ip dhcp-client request vendor-identifying-specific
-!
+# Before state:
+# -----------------------
+# interface port1.0.1
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.2
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.3
+#  description Replaced by Ansible Network
+#  speed 1000
+#  duplex full
+#  shutdown
+#  switchport
+#  switchport mode access
+# !
+# interface port1.0.4
+#  description Override by Ansible Network
+#  duplex full
+#  switchport
+#  switchport mode access
+# !
+# interface vlan1
+#  description Override by Ansible Network
+#  ip address 192.168.5.2/24
+#  ipv6 enable
+#  ipv6 address dhcp
+#  ip dhcp-client vendor-identifying-class
+#  ip dhcp-client request vendor-identifying-specific
+# !
 
-  - name: Test awplus_interface module
-    connection: network_cli
-    hosts: all
-    tasks:
-      - name: "Delete module attributes of given interfaces (Note: This won't delete the interface itself)"
-        awplus_interfaces:source hacking/env-setup
-          config:
-          state: deleted
+- name: "Delete module attributes of given interfaces (Note: This won't delete the interface itself)"
+  alliedtelesis.awplus.awplus_interfaces:
+    config:
+    state: deleted
 
-After state:
----------------------------
-interface port1.0.1
- switchport
- switchport mode access
-!
-interface port1.0.2
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.3
- speed 1000
- duplex full
- switchport
- switchport mode access
-!
-interface port1.0.4
- duplex full
- switchport
- switchport mode access
-!
-interface vlan1
- ip address 192.168.5.2/24
- ipv6 enable
- ipv6 address dhcp
- ip dhcp-client vendor-identifying-class
- ip dhcp-client request vendor-identifying-specific
-!
-
+# After state:
+# ---------------------------
+# interface port1.0.1-1.0.4
+#  switchport
+#  switchport mode access
+# !
+# interface vlan1
+#  ip address 192.168.5.2/24
+#  ipv6 enable
+#  ipv6 address dhcp
+#  ip dhcp-client vendor-identifying-class
+#  ip dhcp-client request vendor-identifying-specific
+# !
 """
+
 RETURN = """
 before:
   description: The configuration prior to the model invocation.
@@ -511,7 +460,11 @@ commands:
   description: The set of commands pushed to the remote device.
   returned: always
   type: list
-  sample: ['command 1', 'command 2', 'command 3']
+  sample: ["interface port1.0.10",
+          "no duplex"
+          "interface port1.0.11",
+          "description Merged by Ansible",
+          "speed 10"]
 """
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/awplus_interfaces.py
+++ b/plugins/modules/awplus_interfaces.py
@@ -49,6 +49,8 @@ options:
         description:
         - Interface link status. Applicable for switchport interfaces only, either in half duplex,
           full duplex or in automatic state which negotiates the duplex automatically.
+        - Note, some AlliedWare Plus devices does not support half duplex. Refer to documentation for
+          valid values.
         type: str
         choices: ['full', 'half', 'auto']
   state:

--- a/plugins/modules/awplus_interfaces.py
+++ b/plugins/modules/awplus_interfaces.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = """
 ---
-module: alliedtelesis.awplus.awplus_interfaces
+module: awplus_interfaces
 author: Cheng Yi Kok (@cyk19)
 short_description: Manages attribute of AlliedWare Plus interfaces
 description: Manages attribute of AlliedWare Plus network interfaces.
@@ -22,7 +22,8 @@ options:
     suboptions:
       name:
         description:
-        - Full name of interface, e.g. port1.0.3, vlan2.
+        - Full name of interface, interface range or comma-separated interfaces.
+          Comma-separated interface names should be of the same type.
         type: str
         required: True
       description:
@@ -37,11 +38,11 @@ options:
         default: True
       speed:
         description:
-        - Interface link speed. Applicable for switchport interfaces only.
+        - Interface link speed. Applicable for ethernet and switchport interfaces only.
         type: str
       mtu:
         description:
-        - MTU size for a specific interface. Applicable for VLAN interfaces only.
+        - MTU size for a specific interface. Applicable for VLAN, ethernet and openflow interfaces only.
         - Refer to documentation for valid values.
         type: int
       duplex:
@@ -53,9 +54,13 @@ options:
   state:
     description:
     - The state of the configuration after module completion.
+    - Note that configuring a range of interfaces with replaced state works the same as merged; and
+      deleted state only works with singular
     choices: ['merged', 'replaced', 'overridden', 'deleted']
     default: merged
     type: str
+note: Configuring a range of interfaces may not be idempotent as the interfaces
+  within the range may have different configurations.
 """
 
 EXAMPLES = """

--- a/tests/unit/modules/test_awplus_interfaces.py
+++ b/tests/unit/modules/test_awplus_interfaces.py
@@ -44,7 +44,7 @@ class TestAwplusInterfacesModule(TestAwplusModule):
         )
 
         self.mock_execute_show_command = patch(
-            "ansible_collections.alliedtelesis.awplus.plugins.module_utils.facts.interfaces.interfaces.InterfacesFacts.get_device_data"
+            "ansible_collections.alliedtelesis.awplus.plugins.module_utils.facts.interfaces.interfaces.InterfacesFacts.get_running_interface"
         )
         self.execute_show_command = self.mock_execute_show_command.start()
 


### PR DESCRIPTION
- Added support for ranges and different stack and board IDs
- Fails when interface does not exist, unknown interface type, invalid range, mismatched type (for comma-separated interfaces)
- Ansible runs with ranges are not idempotent