### PR TITLE
Reinstate legacy module

### DIFF
--- a/plugins/module_utils/network/awplus/facts/facts.py
+++ b/plugins/module_utils/network/awplus/facts/facts.py
@@ -31,9 +31,15 @@ from ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplu
 from ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplus.facts.user.user import UserFacts
 from ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplus.facts.vlans.vlans import VlansFacts
 from ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplus.facts.vrfs.vrfs import VrfsFacts
+from ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplus.facts.legacy.base import Default, Hardware, Config, Interfaces
 
 
-FACT_LEGACY_SUBSETS = {}
+FACT_LEGACY_SUBSETS = dict(
+    default=Default,
+    hardware=Hardware,
+    config=Config,
+    interfaces=Interfaces,
+)
 FACT_RESOURCE_SUBSETS = dict(
     banner=BannerFacts,
     bgp=BgpFacts,

--- a/plugins/module_utils/network/awplus/facts/legacy/base.py
+++ b/plugins/module_utils/network/awplus/facts/legacy/base.py
@@ -1,0 +1,374 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Allied Telesis
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+The awplus legacy fact class
+It is in this file the configuration is collected from the device
+for a given resource, parsed, and the facts tree is populated
+based on the configuration.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import re
+import sys
+
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
+from ansible_collections.alliedtelesis.awplus.plugins.module_utils.awplus import (
+    run_commands,
+    get_capabilities,
+)
+from ansible_collections.alliedtelesis.awplus.plugins.module_utils.utils.utils import (
+    normalize_interface,
+)
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves import zip
+
+
+class FactsBase(object):
+
+    COMMANDS = list()
+
+    def __init__(self, module):
+        self.module = module
+        self.facts = dict()
+        self.warnings = list()
+        self.responses = None
+
+    def populate(self):
+        self.responses = run_commands(
+            self.module, commands=self.COMMANDS, check_rc=False
+        )
+
+    def run(self, cmd):
+        return run_commands(self.module, commands=cmd, check_rc=False)
+
+
+class Default(FactsBase):
+    COMMANDS = ["show system"]
+
+    def populate(self):
+        super(Default, self).populate()
+        self.facts.update(self.platform_facts())
+        data = self.responses[0]
+        if data:
+            self.facts["serialnum"] = self.parse_serialnum(data)
+
+    def parse_serialnum(self, data):
+        match_num = 5
+        match = re.search(
+            r"^Base\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$", data, re.M
+        )
+        if not match:
+            match_num = 6
+            match = re.search(
+                r"^Base\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$", data, re.M
+            )
+        if match:
+            return match.group(match_num)
+        return "--unknown--"
+
+    def platform_facts(self):
+        platform_facts = {}
+
+        resp = get_capabilities(self.module)
+        device_info = resp["device_info"]
+
+        platform_facts["system"] = device_info["network_os"]
+        for item in ("model", "image", "version", "platform", "hostname"):
+            val = device_info.get("network_os_%s" % item)
+            if val:
+                platform_facts[item] = val
+
+        platform_facts["api"] = resp["network_api"]
+        return platform_facts
+
+
+class Hardware(FactsBase):
+
+    COMMANDS = ["show file systems", "show system"]
+
+    def populate(self):
+        warnings = list()
+        super(Hardware, self).populate()
+        data = self.responses[0]
+        if data:
+            self.facts["filesystems"] = self.parse_filesystems(data)
+            self.facts["filesystems_info"] = self.parse_filesystems_info(data)
+
+        data = self.responses[1]
+        if data:
+            if "Invalid input detected" in data:
+                warnings.append("Unable to gather memory statistics")
+            else:
+                match = re.search(
+                    r"Flash:\s+([0-9]*[.]?[0-9]+[A-Z]+).+Available:\s+([0-9]*[.]?[0-9]+[A-Z]+)",
+                    data,
+                )
+                if match:
+                    self.facts["memtotal"] = match.group(1)
+                    self.facts["memfree"] = match.group(2)
+
+    def parse_filesystems(self, data):
+        return re.findall(r"\s+(\w+)\s+r[w|o]", data, re.M)
+
+    def parse_filesystems_info(self, data):
+        facts = dict()
+        fs = ""
+        test = ""
+        for line in data.split("\n"):
+            match = re.match(r".+\s+(\w+)\s+r[w|o].+", line, re.M)
+            if match:
+                fs = match.group(1)
+                facts[fs] = dict()
+                match = re.match(
+                    r"\s+([0-9]*[.]?[0-9]+[A-Z]+)\s+([0-9]*[.]?[0-9]+[A-Z]+).+", line
+                )
+                if match:
+                    facts[fs]["spacetotal"] = match.group(1)
+                    facts[fs]["spacefree"] = match.group(2)
+
+        return facts
+
+
+class Config(FactsBase):
+
+    COMMANDS = ["show running-config"]
+
+    def populate(self):
+        super(Config, self).populate()
+        data = self.responses[0]
+        if data:
+            data = re.sub(
+                r"^Building configuration...\s+Current configuration  :  \d+ bytes\n",
+                "",
+                data,
+                flags=re.MULTILINE,
+            )
+            self.facts["config"] = data
+
+
+class Interfaces(FactsBase):
+
+    COMMANDS = [
+        "show interface",
+        "show ip interface",
+        "show ipv6 interface",
+        "show ip irdp interface",
+        "show lldp",
+    ]
+
+    def populate(self):
+        super(Interfaces, self).populate()
+
+        self.facts["all_ipv4_addresses"] = list()
+        self.facts["all_ipv6_addresses"] = list()
+        self.facts["neighbors"] = {}
+
+        data = self.responses[0]
+        if data:
+            interfaces = self.parse_interfaces(data)
+            self.facts["interfaces"] = self.populate_interfaces(interfaces)
+
+        data = self.responses[1]
+        if data:
+            data = self.parse_ip_interfaces(data)
+            self.populate_ipv4_interfaces(data)
+
+        data = self.responses[2]
+        if data:
+            data = self.parse_ip_interfaces(data)
+            self.populate_ipv6_interfaces(data)
+
+        data = self.responses[3]
+        if data:
+            data = self.parse_irdp_interfaces(data)
+            self.populate_line_protocol(data)
+
+        data = self.responses[4]
+        lldp_errs = ["Invalid input", "LLDP is not enabled"]
+
+        if data and not any(err in data for err in lldp_errs):
+            neighbors = self.run(["show lldp"])
+            if neighbors:
+                self.facts["neighbors"].update(self.parse_neighbors(neighbors[0]))
+
+    def populate_interfaces(self, interfaces):
+        facts = dict()
+        for key, value in iteritems(interfaces):
+            intf = dict()
+            intf["description"] = self.parse_description(value)
+            intf["macaddress"] = self.parse_macaddress(value)
+            intf["mtu"] = self.parse_mtu(value)
+            intf["bandwidth"] = self.parse_bandwidth(value)
+            intf["duplex"] = self.parse_duplex(value)
+            intf["operstatus"] = self.parse_operstatus(value)
+            intf["type"] = self.parse_type(value)
+
+            facts[key] = utils.remove_empties(intf)
+        return facts
+
+    def populate_ipv4_interfaces(self, data):
+        for key, value in data.items():
+            self.facts["interfaces"][key]["ipv4"] = list()
+            match = re.search(r"^(\w+)\s+(\S+)\s+(.+)\s+(\w+)", value, re.M)
+            if "/" not in match.group(2):
+                continue
+            else:
+                address = match.group(2)
+                addr, subnet = address.split("/")
+                ipv4 = dict(address=addr.strip(), subnet=subnet.strip())
+                self.add_ip_address(addr.strip(), "ipv4")
+                self.facts["interfaces"][key]["ipv4"].append(ipv4)
+
+    def populate_ipv6_interfaces(self, data):
+        for key, value in iteritems(data):
+            try:
+                self.facts["interfaces"][key]["ipv6"] = list()
+            except KeyError:
+                self.facts["interfaces"][key] = dict()
+                self.facts["interfaces"][key]["ipv6"] = list()
+            match = re.search(r"^(\w+)\s+(\S+)\s+(.+)\s+(\w+)\s+(\w+)", value, re.M)
+            if "/" not in match.group(2):
+                continue
+            else:
+                address = match.group(2)
+                addr, subnet = address.split("/")
+                ipv4 = dict(address=addr.strip(), subnet=subnet.strip())
+                self.add_ip_address(addr.strip(), "ipv6")
+                self.facts["interfaces"][key]["ipv6"].append(ipv4)
+
+    def populate_line_protocol(self, data):
+        for key, value in iteritems(data):
+            try:
+                self.facts["interfaces"][key]["lineprotocol"] = None
+            except KeyError:
+                self.facts["interfaces"][key] = dict()
+                self.facts["interfaces"][key]["lineprotocol"] = None
+            lineprotocol = self.parse_lineprotocol(value)
+            self.facts["interfaces"][key]["lineprotocol"] = lineprotocol
+
+    def add_ip_address(self, address, family):
+        if family == "ipv4":
+            self.facts["all_ipv4_addresses"].append(address)
+        else:
+            self.facts["all_ipv6_addresses"].append(address)
+
+    def parse_neighbors(self, neighbors):
+        facts = dict()
+        for entry in neighbors.split(
+            "------------------------------------------------"
+        ):
+            if entry == "":
+                continue
+            intf = self.parse_lldp_intf(entry)
+            if intf is None:
+                return facts
+            intf = normalize_interface(intf)
+            if intf not in facts:
+                facts[intf] = list()
+            fact = dict()
+            fact["host"] = self.parse_lldp_host(entry)
+            fact["port"] = self.parse_lldp_port(entry)
+            facts[intf].append(fact)
+        return facts
+
+    def parse_ip_interfaces(self, data):
+        parsed = dict()
+        key = ""
+        for line in data.split("\n"):
+            if len(line) == 0:
+                continue
+            elif line[0] == " ":
+                continue
+            else:
+                match = re.match(r"^([a-z]+[0-9]*)\s+", line)
+                if match:
+                    key = match.group(1)
+                    parsed[key] = line
+        return parsed
+
+    def parse_interfaces(self, data):
+        parsed = dict()
+        key = ""
+        for line in data.split("\n"):
+            if len(line) == 0:
+                continue
+            elif line[0] == " ":
+                parsed[key] += "\n%s" % line
+            else:
+                match = re.match(r"^Interface (\S+)", line)
+                if match:
+                    key = match.group(1)
+                    parsed[key] = line
+        return parsed
+
+    def parse_irdp_interfaces(self, data):
+        parsed = dict()
+        key = ""
+        for line in data.split("\n"):
+            if len(line) != 0:
+                match = re.match(r"^([a-z\d\.]+)", line)
+                if match:
+                    key = match.group(1)
+                    parsed[key] = line
+        return parsed
+
+    def parse_description(self, data):
+        match = re.search(r"Description: (.+)$", data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_macaddress(self, data):
+        match = re.search(r"Hardware is (?:.*), address is (\S+)", data)
+        if match:
+            return match.group(1)
+
+    def parse_mtu(self, data):
+        match = re.search(r"mtu (\d+)", data)
+        if match:
+            return int(match.group(1))
+
+    def parse_bandwidth(self, data):
+        match = re.search(r"Bandwidth (.+)", data)
+        if match:
+            return match.group(1)
+
+    def parse_duplex(self, data):
+        match = re.search(r"configured duplex (\w+)", data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_type(self, data):
+        match = re.search(r"Hardware is ([A-Z]+[a-z]*)", data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_lineprotocol(self, data):
+        match = re.search(r"line protocol is (\S+)\s*$", data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_operstatus(self, data):
+        match = re.search(r"^(?:.+) is (.+),", data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_lldp_intf(self, data):
+        match = re.search(r"^Local Intf: (.+)$", data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_lldp_host(self, data):
+        match = re.search(r"System Name: (.+)$", data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_lldp_port(self, data):
+        match = re.search(r"Port id: (.+)$", data, re.M)
+        if match:
+            return match.group(1)

--- a/tests/unit/modules/test_awplus_facts.py
+++ b/tests/unit/modules/test_awplus_facts.py
@@ -1,0 +1,129 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.alliedtelesis.awplus.tests.unit.compat.mock import patch
+from ansible_collections.alliedtelesis.awplus.plugins.modules import awplus_facts
+from ansible.module_utils.six import assertCountEqual
+from ansible_collections.alliedtelesis.awplus.tests.unit.utils import set_module_args
+from .awplus_module import TestAwplusModule, load_fixture
+
+
+class TestAwplusFactsModule(TestAwplusModule):
+    module = awplus_facts
+
+    def setUp(self):
+        super(TestAwplusModule, self).setUp()
+        self.mock_run_commands = patch(
+            "ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplus.facts.legacy.base.run_commands"
+        )
+        self.run_commands = self.mock_run_commands.start()
+
+        self.mock_get_resource_connection_config = patch(
+            'ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base.get_resource_connection'
+        )
+        self.get_resource_connection_config = self.mock_get_resource_connection_config.start()
+
+        self.mock_get_resource_connection_facts = patch(
+            'ansible_collections.ansible.netcommon.plugins.module_utils.network.common.facts.facts.get_resource_connection'
+        )
+        self.get_resource_connection_facts = self.mock_get_resource_connection_facts.start()
+
+        self.mock_get_capabilities = patch(
+            "ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplus.facts.legacy.base.get_capabilities"
+        )
+        self.get_capabilities = self.mock_get_capabilities.start()
+        self.get_capabilities.return_value = {
+            "device_info": {
+                "network_os": "awplus",
+                "network_os_hostname": "AR2050",
+                "network_os_model": "AR2050V",
+                "network_os_image": "flash:/default.cfg",
+                "network_os_version": "main-20191128-1",
+            },
+            "network_api": "cliconf",
+        }
+
+    def tearDown(self):
+        super(TestAwplusFactsModule, self).tearDown()
+        self.mock_run_commands.stop()
+        self.mock_get_capabilities.stop()
+
+    def load_fixtures(self, commands=None):
+        def load_from_file(*args, **kwargs):
+            module = args
+            commands = kwargs["commands"]
+            output = list()
+
+            for command in commands:
+                filename = str(command).split(" | ")[0].replace(" ", "_")
+                output.append(load_fixture("awplus_facts_%s" % filename))
+            return output
+
+        self.run_commands.side_effect = load_from_file
+
+    def test_awplus_facts_filesystems_info(self):
+        set_module_args(dict(gather_subset="hardware"))
+        result = self.execute_module()
+        self.assertEqual(
+            result["ansible_facts"]["ansible_net_filesystems_info"]["debug"][
+                "spacetotal"
+            ],
+            "10M",
+        )
+        self.assertEqual(
+            result["ansible_facts"]["ansible_net_filesystems_info"]["debug"][
+                "spacefree"
+            ],
+            "9.7M",
+        )
+
+    def test_awplus_facts_neighbors(self):
+        pass
+
+    def test_awplus_facts_hostname(self):
+        set_module_args(dict(gather_subset="default"))
+        result = self.execute_module()
+        self.assertEqual(result["ansible_facts"]["ansible_net_hostname"], "AR2050")
+
+    def test_awplus_all_ipv4_address(self):
+        set_module_args(dict(gather_subset="interfaces"))
+        result = self.execute_module()
+        self.assertEqual(
+            len(result["ansible_facts"]["ansible_net_all_ipv4_addresses"]), 1
+        )
+
+    def test_awplus_interfaces(self):
+        set_module_args(dict(gather_subset="interfaces"))
+        result = self.execute_module()
+        self.assertEqual(
+            result["ansible_facts"]["ansible_net_interfaces"]["br0"]["type"], "Bridge"
+        )
+
+        self.assertEqual(
+            result["ansible_facts"]["ansible_net_interfaces"]["eth1"]["operstatus"],
+            "DOWN",
+        )
+
+        self.assertEqual(
+            result["ansible_facts"]["ansible_net_interfaces"]["port1.0.1"][
+                "macaddress"
+            ],
+            "001a.eb94.27bb",
+        )


### PR DESCRIPTION
A module removed in moving to the resource module way of working really
needs to be there to provide some basic system information. However, it
does end up in a new position in the file structure.