### PR TITLE
Fixes to allow Galaxy workflow to pass

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,4 +17,8 @@ namespace: alliedtelesis
 readme: README.md
 repository: "https://github.com/alliedtelesis/ansible_awplus"
 tags: ["networking"]
+build_ignore:
+- .vscode
+- .github
+- .gitignore
 version: 1.2.0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.9"

--- a/plugins/module_utils/awplus.py
+++ b/plugins/module_utils/awplus.py
@@ -46,7 +46,7 @@ def get_connection(module):
     if network_api == "cliconf":  # Use awplus cliconf to run command on AW+ platform
         module._awplus_connection = Connection(module._socket_path)
     else:
-        module.fail_json(msg="Invalid connection type %s".format(network_api))
+        module.fail_json(msg="Invalid connection type {}".format(network_api))
 
     return module._awplus_connection
 

--- a/plugins/module_utils/network/awplus/config/banner/banner.py
+++ b/plugins/module_utils/network/awplus/config/banner/banner.py
@@ -167,7 +167,6 @@ class Banner(ConfigBase):
         else:
             for name, want_dict in iteritems(want):
                 if name in have:
-                    have_dict = have[name]
                     commands.extend(_clear_config(name))
 
         return commands

--- a/plugins/module_utils/network/awplus/config/lacp_interfaces/lacp_interfaces.py
+++ b/plugins/module_utils/network/awplus/config/lacp_interfaces/lacp_interfaces.py
@@ -17,7 +17,6 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
     to_list,
     param_list_to_dict,
     iteritems,
-    dict_diff,
 )
 from ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplus.facts.facts import Facts
 from ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplus.utils.utils import (

--- a/plugins/module_utils/network/awplus/config/ntp/ntp.py
+++ b/plugins/module_utils/network/awplus/config/ntp/ntp.py
@@ -16,7 +16,6 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.c
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
     remove_empties,
-    dict_diff,
 )
 from ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplus.facts.facts import Facts
 

--- a/plugins/module_utils/network/awplus/facts/banner/banner.py
+++ b/plugins/module_utils/network/awplus/facts/banner/banner.py
@@ -9,7 +9,6 @@ It is in this file the configuration is collected from the device
 for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/awplus/facts/facts.py
+++ b/plugins/module_utils/network/awplus/facts/facts.py
@@ -9,7 +9,6 @@ this file validates each subset of facts and selectively
 calls the appropriate facts gathering function
 """
 
-from ansible_collections.alliedtelesis.awplus.plugins.module_utils.network.awplus.argspec.facts.facts import FactsArgs
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.facts.facts import (
     FactsBase,
 )

--- a/plugins/module_utils/network/awplus/facts/legacy/base.py
+++ b/plugins/module_utils/network/awplus/facts/legacy/base.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import re
-import sys
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 from ansible_collections.alliedtelesis.awplus.plugins.module_utils.awplus import (
@@ -27,7 +26,6 @@ from ansible_collections.alliedtelesis.awplus.plugins.module_utils.utils.utils i
     get_sys_info,
 )
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.six.moves import zip
 
 
 class FactsBase(object):
@@ -112,7 +110,6 @@ class Hardware(FactsBase):
     def parse_filesystems_info(self, data):
         facts = dict()
         fs = ""
-        test = ""
         for line in data.split("\n"):
             match = re.match(r".+\s+(\w+)\s+r[w|o].+", line, re.M)
             if match:

--- a/plugins/module_utils/network/awplus/facts/logging/logging.py
+++ b/plugins/module_utils/network/awplus/facts/logging/logging.py
@@ -9,7 +9,6 @@ It is in this file the configuration is collected from the device
 for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/awplus/facts/ntp/ntp.py
+++ b/plugins/module_utils/network/awplus/facts/ntp/ntp.py
@@ -9,7 +9,6 @@ It is in this file the configuration is collected from the device
 for a given resource, parsed, and the facts tree is populated
 based on the configuration.
 """
-import re
 from copy import deepcopy
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (

--- a/plugins/module_utils/network/awplus/facts/vrfs/vrfs.py
+++ b/plugins/module_utils/network/awplus/facts/vrfs/vrfs.py
@@ -79,8 +79,8 @@ class VrfsFacts(object):
         """
         config = deepcopy(spec)
 
-        for l in conf.splitlines():
-            ls = l.strip()
+        for conf_line in conf.splitlines():
+            ls = conf_line.strip()
             if ls.startswith('ip vrf'):
                 match = re.search(r'ip vrf (\S+) (\d+)', ls)
                 if match:

--- a/plugins/module_utils/network/awplus/utils/utils.py
+++ b/plugins/module_utils/network/awplus/utils/utils.py
@@ -6,8 +6,6 @@
 
 # utils
 import re
-from ansible.module_utils.six import iteritems
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import is_masklen
 
 
 def remove_command_from_config_list(interface, cmd, commands):

--- a/plugins/modules/awplus_config.py
+++ b/plugins/modules/awplus_config.py
@@ -254,7 +254,6 @@ from ansible_collections.alliedtelesis.awplus.plugins.module_utils.awplus import
     get_config,
 )
 from ansible_collections.alliedtelesis.awplus.plugins.module_utils.awplus import (
-    get_defaults_flag,
     get_connection,
 )
 from ansible_collections.alliedtelesis.awplus.plugins.module_utils.awplus import (

--- a/plugins/modules/awplus_facts.py
+++ b/plugins/modules/awplus_facts.py
@@ -76,12 +76,7 @@ EXAMPLES = """
 """
 
 RETURN = """
-
-
-See the respective resource module parameters for the tree.
-
-
-
+description: See the respective resource module parameters for the tree.
 """
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/awplus_ipv6_ospf.py
+++ b/plugins/modules/awplus_ipv6_ospf.py
@@ -27,6 +27,7 @@ author:
     - Isaac Daly (@dalyIsaac)
 notes:
     - C(state=present) is the default for all state options.
+    - Check mode is supported.
 options:
   router:
     description:
@@ -42,8 +43,6 @@ options:
                 - A positive integer in the range 1 to 65535 used to define a routing
                   process.
     required: True
-notes:
-    - Check mode is supported.
 """
 
 

--- a/plugins/modules/awplus_system.py
+++ b/plugins/modules/awplus_system.py
@@ -94,7 +94,7 @@ commands:
     type: list
     sample:
         - hostname awplus01
-      - ip domain name test.example.com
+        - ip domain name test.example.com
 """
 
 import re


### PR DESCRIPTION
A number of failures when submitting the collection to Galaxy need to
be addressed, including a number of flake8 issues and issues with
documentation strings.

Also added a new file meta/runtime.yml which seems to be required now,
and with a "requires_ansible" tag in it.

Also add options to galaxy.yml to exclude some files from the collection
build.