### PR TITLE
L2_interfaces fixes

### DIFF
--- a/plugins/module_utils/network/awplus/argspec/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/awplus/argspec/l2_interfaces/l2_interfaces.py
@@ -40,7 +40,7 @@ class L2_interfacesArgs(object):  # pylint: disable=R0903
                 'vlan': {'required': True, 'type': 'int'}}, 'type': 'dict'},
             'name': {'required': True, 'type': 'str'},
             'trunk': {'options': {
-                'allowed_vlans': {'elements': 'int', 'type': 'list'},
+                'allowed_vlans': {'elements': 'str', 'type': 'list'},
                 'native_vlan': {'type': 'int'}}, 'type': 'dict'}}, 'type': 'list'},
         'state': {'choices': ['merged', 'replaced', 'overridden', 'deleted'], 'default': 'merged', 'type': 'str'}}
     # pylint: disable=C0301

--- a/tests/playbook/pb_test_l2_interfaces.py
+++ b/tests/playbook/pb_test_l2_interfaces.py
@@ -37,6 +37,11 @@ tests = {
     "replace_10": ['interface port1.0.6', 'switchport trunk native vlan 22'],
     "replace_11": ['interface port1.0.4', 'switchport trunk native vlan none'],
     "replace_12": ['interface port1.0.7', 'switchport trunk native vlan 99'],
+    "replace_13": ["interface port1.0.6", "switchport trunk allowed vlan add 9", "switchport trunk allowed vlan add 10"],
+    "replace_14": ["interface port1.0.2", "switchport trunk allowed vlan add 8", "switchport trunk allowed vlan add 9",
+                   "switchport trunk allowed vlan add 10", "switchport trunk allowed vlan remove 6"],
+    "replace_15": ["interface port1.0.2", "switchport trunk allowed vlan add 1", "switchport trunk allowed vlan add 2",
+                   "switchport trunk allowed vlan add 4", "switchport trunk allowed vlan remove 5", "switchport trunk allowed vlan remove 7"],
     "override_1": ['interface port1.0.1', 'switchport access vlan 101', 'interface port1.0.2',
                    'switchport mode access', 'switchport access vlan 102', 'interface port1.0.3',
                    'switchport mode access', 'switchport access vlan 103', 'interface port1.0.4',
@@ -90,6 +95,11 @@ tests = {
     "merged_12": ['interface port1.0.4', 'switchport trunk native vlan none'],
     "merged_13": ['interface port1.0.7', 'switchport trunk native vlan 99'],
     "merged_14": [],
+    "merged_15": ["interface port1.0.3", "switchport trunk allowed vlan add 9", "switchport trunk allowed vlan add 10"],
+    "merged_16": ["interface port1.0.2", "switchport trunk allowed vlan add 8",
+                  "switchport trunk allowed vlan add 9", "switchport trunk allowed vlan add 10", "switchport trunk allowed vlan add 2"],
+    "merged_17": ["interface port1.0.2", "switchport trunk allowed vlan add 1",
+                  "switchport trunk allowed vlan add 2", "switchport trunk allowed vlan add 4"]
 }
 
 
@@ -106,15 +116,21 @@ def parse_output(op):
     for outl in op.splitlines():
         ls = outl.strip()
         if looking:
-            if ls.startswith(('ok:', 'changed:')) and ls.endswith('{'):
+            if ls.startswith(('ok:', 'changed:')):
                 pop = "{"
                 looking = False
         else:
-            pop += ls
-            if outl.rstrip() == '}':
-                break
+            if ls.startswith('changed:'):
+                pop += ls
+                if outl.rstrip() == '}':
+                    break
+
     pop = pop.replace("false", "False")
     pop = pop.replace("true", "True")
+    pop = pop.replace("null", "None")
+    pop = pop.replace('{changed: [aw2] => ', '')
+    pop = pop.replace('ok: [aw2] => ', '')
+
     try:
         pop = ast.literal_eval(pop)
     except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
@@ -265,6 +281,26 @@ def test_replace_12():
     assert run_a_test('replace_12')
 
 
+def test_replace_11():
+    assert run_a_test('replace_11')
+
+
+def test_replace_12():
+    assert run_a_test('replace_12')
+
+
+def test_replace_13():
+    assert run_a_test('replace_13')
+
+
+def test_replace_14():
+    assert run_a_test('replace_14')
+
+
+def test_replace_15():
+    assert run_a_test('replace_15')
+
+
 def test_override_1():
     assert run_a_test('override_1')
 
@@ -323,3 +359,15 @@ def test_merged_13():
 
 def test_merged_14():
     assert run_a_test('merged_14')
+
+
+def test_merged_15():
+    assert run_a_test('merged_15')
+
+
+def test_merged_16():
+    assert run_a_test('merged_16')
+
+
+def test_merged_17():
+    assert run_a_test('merged_17')

--- a/tests/playbook/tests_l2_interfaces.yml
+++ b/tests/playbook/tests_l2_interfaces.yml
@@ -338,6 +338,31 @@
               allowed_vlans: 902, 9, 703, 231, 10, 450, 348, 705
         state: replaced
 
+    - name: Replaced test - replace range of allowed vlans
+      tags:
+        - replace_14
+      awplus_l2_interfaces:
+        config:
+          - name: port1.0.2
+            trunk:
+              allowed_vlans: 7-11, 5
+        state: replaced
+
+    - name: Replaced test - replace list of allowed vlans
+      tags:
+        - replace_15
+      awplus_l2_interfaces:
+        config:
+          - name: port1.0.2
+            trunk:
+              allowed_vlans:
+                - 1
+                - 2
+                - 4
+                - 6
+                - 11
+        state: replaced
+
     - name: Override all VLANs
       tags:
         - override_1
@@ -649,4 +674,28 @@
           - name: port1.0.3
             trunk:
               allowed_vlans: 902, 9, 703, 231, 10, 450, 348, 705
+        state: merged
+
+    - name: Merge test - merge range of allowed vlans
+      tags:
+        - merged_16
+      awplus_l2_interfaces:
+        config:
+          - name: port1.0.2
+            trunk:
+              allowed_vlans: 8-11, 2
+        state: merged
+
+    - name: Merge test - merge list of allowed vlans
+      tags:
+        - merged_17
+      awplus_l2_interfaces:
+        config:
+          - name: port1.0.2
+            trunk:
+              allowed_vlans:
+                - 1
+                - 2
+                - 4
+                - 11
         state: merged


### PR DESCRIPTION
- argspec: corrected allowed_vlans 'elements to match model
- config:
  - added support for ranges of allowed_vlans
  - renamed get_vlan_conf to check_vlan_conf
  - clean up of function descriptions
  - native_vlan and access vlan now gets checked through check_vlan_conf
  - allowed_vlans can now only be adjusted if the mode does not change to 'access'
- added more tests to test playbook
- added more tests to playbook wrapper and changed code in parse output